### PR TITLE
yuck: build again from sources (version 20221101+)

### DIFF
--- a/Formula/yuck.rb
+++ b/Formula/yuck.rb
@@ -1,8 +1,9 @@
 class Yuck < Formula
   desc "Local-search constraint solver with FlatZinc interface"
   homepage "https://github.com/informarte/yuck"
-  url "https://github.com/informarte/yuck/releases/download/20221101/yuck-20221101.zip"
-  sha256 "2195b8b4280f81326c7a9710f2ac1f6a3be7176c9235d12ec0e813a43a2655da"
+  url "https://github.com/informarte/yuck.git",
+     tag:      "20221101",
+     revision: "964c71eb53b80909b7a04090e7ce7a7393bec112"
   license "MPL-2.0"
   head "https://github.com/informarte/yuck.git", branch: "master"
 
@@ -12,15 +13,14 @@ class Yuck < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "a73efafac2b2ab3cf0ad3bd0274f147ccfee3f0e568ef14bd6411336db8b1378"
   end
 
-  # FIXME: Building does not succeed in the formula <== depends_on "mill" => :build
+  depends_on "mill" => :build
   depends_on "coreutils" # realpath in script
   depends_on "openjdk"
 
   def install
-    # system "mill", "yuck.universalPackage"
+    system "mill", "yuck.dev.universalPackage"
 
-    # out_loc = buildpath / Dir.glob("out/yuck/corePackage.dest/yuck-*")[0]
-    out_loc = buildpath
+    out_loc = buildpath / Dir.glob("out/yuck/dev/corePackage.dest/yuck-*")[0]
 
     inreplace (out_loc / "bin/yuck") do |s|
       s.gsub!("APP_HOME\/lib", "APP_HOME\/libexec")
@@ -32,13 +32,13 @@ class Yuck < Formula
     (share / "minizinc").mkpath
     (share / "minizinc").install (out_loc / "mzn/lib") => "yuck"
 
-    inreplace "mzn/yuck.msc" do |s|
+    inreplace "resources/mzn/yuck.msc.in" do |s|
       s.gsub!(/"executable":\s+"[^"]*"/, "\"executable\": \"#{bin}/yuck\"")
       s.gsub!(/"mznlib":\s+"[^"]*"/, "\"mznlib\": \"#{share}/minizinc/yuck\"")
       s.gsub!(/"version":\s+"[^"]*"/, "\"version\": \"#{version}\"")
     end
     (share / "minizinc/solvers").mkpath
-    (share / "minizinc/solvers").install "mzn/yuck.msc"
+    (share / "minizinc/solvers").install "resources/mzn/yuck.msc.in" => "yuck.msc"
   end
 
   test do


### PR DESCRIPTION
The current Yuck formula uses a build produced by the solver owner. However, in the future we should again build this software so we are sure it abides by the Homebrew standards.

Current blocking issues are:
- The current version of the builder `mill` throws an error when outputting an warning for the newer Java version.
- A mysterious type error appears when using the current develop version of `mill`:
```
TypeError: no implicit conversion of nil into String
```