### PR TITLE
choco: use included script for fzn-choco

### DIFF
--- a/Formula/choco.rb
+++ b/Formula/choco.rb
@@ -1,4 +1,6 @@
 class Choco < Formula
+  include Language::Python::Shebang
+
   desc "Open-Source Java library for Constraint Programming and FlatZinc solver"
   homepage "https://choco-solver.org"
   url "https://github.com/chocoteam/choco-solver/archive/refs/tags/v5.0.0.tar.gz"
@@ -14,12 +16,21 @@ class Choco < Formula
 
   depends_on "maven" => :build
   depends_on "openjdk"
+  depends_on "python@3.13"
+
+  patch :DATA
 
   def install
     cd "parsers" do
       system "mvn", "clean", "package", "-DskipTests=true", "-Dmaven.javadoc.skip=true"
-      libexec.install "target/choco-parsers-#{version}-jar-with-dependencies.jar"
-      bin.write_jar_script libexec/"choco-parsers-#{version}-jar-with-dependencies.jar", "fzn-choco"
+      libexec.install "target/choco-solver-#{version}-light.jar" => "choco-parsers-#{version}-light.jar"
+
+      rewrite_shebang detected_python_shebang, "src/main/minizinc/fzn-choco.py"
+      inreplace "src/main/minizinc/fzn-choco.py" do |s|
+        s.gsub!(/JAR_FILE\s*=\s*'[^']*'/, "JAR_FILE='#{libexec}/choco-parsers-#{version}-light.jar'")
+        s.gsub!("HOMEBREW_JAVA_HOME", Language::Java.java_home)
+      end
+      bin.install "src/main/minizinc/fzn-choco.py" => "fzn-choco"
 
       (share / "minizinc").mkpath
       (share / "minizinc").install "src/main/minizinc/mzn_lib" => "choco"
@@ -41,3 +52,25 @@ class Choco < Formula
     assert_match "----------", shell_output("#{bin}/fzn-choco test.fzn").strip
   end
 end
+
+__END__
+diff --git a/parsers/src/main/minizinc/fzn-choco.py b/parsers/src/main/minizinc/fzn-choco.py
+index 9965727..711dc16 100644
+--- a/parsers/src/main/minizinc/fzn-choco.py
++++ b/parsers/src/main/minizinc/fzn-choco.py
+@@ -1,3 +1,5 @@
++#!/usr/bin/env python3
++
+ # Compilation mode, support OS-specific options
+ # nuitka-project: --onefile
+ # nuitka-project: --remove-output
+@@ -107,7 +109,8 @@ if args.cp_profiler:
+ if args.lazy_clause_generation:
+     arguments += ' -lcg'
+
+-cmd = f'java {args.jvm_args} -cp {args.jar_file} org.chocosolver.parser.flatzinc.ChocoFZN {args.fzn_file} {arguments}'
++os.environ.setdefault("JAVA_HOME", "HOMEBREW_JAVA_HOME")
++cmd = f'${{JAVA_HOME}}/bin/java {args.jvm_args} -cp {args.jar_file} org.chocosolver.parser.flatzinc.ChocoFZN {args.fzn_file} {arguments}'
+
+ # if __lvl__ == 'INFO':
+ #cprint(f'Running command: {cmd}')


### PR DESCRIPTION
This also switches the used JAR file to `choco-parsers-#{version}-light.jar`. This is the JAR file the maintainer distribute as well.