### PR TITLE
rebuild out-of-date bottles

### DIFF
--- a/Formula/chuffed.rb
+++ b/Formula/chuffed.rb
@@ -8,6 +8,7 @@ class Chuffed < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sonoma: "6222a6b1cd0c2b0b0fe9531e22876a00720983ceb1e7a348737d8a7045835191"
     sha256 cellar: :any_skip_relocation, ventura:      "05155a13d9377e2a982925f978b1027847c53d847cb4c402ad194184074b4bef"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "17b228b49295cf9f5da4e32e30ca6c0cecbd96f59c5905845ceb03260cda264c"

--- a/Formula/clingcon.rb
+++ b/Formula/clingcon.rb
@@ -7,6 +7,7 @@ class Clingcon < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any,                 ventura:      "f16d1f5bfb4365d8c6cccdb0c348b488403cabe796199b707c29ad1ee8c46006"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "2fb12a9e958f0c3f01d0f0176e2dceb89228e21650685c9464dd71e099591752"
   end

--- a/Formula/findmus.rb
+++ b/Formula/findmus.rb
@@ -2,7 +2,7 @@ class Findmus < Formula
   desc "Tool to find minimal unsatisfiable subsets of constraints in a MiniZinc instance"
   homepage "https://gitlab.com/minizinc/FindMUS"
   url "https://gitlab.com/minizinc/FindMUS.git",
-    revision: "8abdc8039657ef6277be8b34c3e83ea77bedaa70"
+    revision: "d986e4e114a11eddb7def41837f900e00845a800"
   version "0.7.0"
   license "MPL-2.0"
   head "https://gitlab.com/minizinc/FindMUS.git", branch: "master"
@@ -15,7 +15,15 @@ class Findmus < Formula
   end
 
   depends_on "cmake" => :build
+  # cbc, cgl, clp, coinutils, gecode and osi are minizinc dependencies that the
+  # findmus binary links against transitively.
+  depends_on "cbc"
+  depends_on "cgl"
+  depends_on "clp"
+  depends_on "coinutils"
+  depends_on "gecode"
   depends_on "minizinc"
+  depends_on "osi"
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args

--- a/Formula/findmus.rb
+++ b/Formula/findmus.rb
@@ -9,7 +9,7 @@ class Findmus < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
-    rebuild 1
+    rebuild 2
     sha256 cellar: :any,                 big_sur:      "b7442e71744d1898257b807ea8e12b6920621eb5ca03907d223c17d2af20ca6b"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "fbaa7bf8431366dd02d339333327c004cd0ab401d6c4f68571787e0664a1fdea"
   end

--- a/Formula/flatzingo.rb
+++ b/Formula/flatzingo.rb
@@ -8,6 +8,7 @@ class Flatzingo < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any_skip_relocation, big_sur:      "8732bfe5a1f8cb8ff603edb629d087ebaebd6d99c12f195f02bd6558a4576d5e"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "c7e56a8c706e7a28d55b6599bf7a8e0a3f016cb684dc4f6f18893d01ad37b656"
   end

--- a/Formula/fzn-oscar-cbls.rb
+++ b/Formula/fzn-oscar-cbls.rb
@@ -8,6 +8,7 @@ class FznOscarCbls < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any_skip_relocation, big_sur:      "7861df5fdda7f1cff3ff833b8f06e6f20d991cb39db3e49e9e534d01af9fd00f"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "7456db85bd6fa321f7dc881aff8ff2836470fcad8897e0fb4dcca4d9f1b8871d"
   end

--- a/Formula/fzn-picat.rb
+++ b/Formula/fzn-picat.rb
@@ -9,6 +9,7 @@ class FznPicat < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sonoma: "7583e69993dc4e42ccdf31c8479fa487d0a2d970302455e2c93fafb8ae1ab0f1"
     sha256 cellar: :any_skip_relocation, ventura:      "f0c91e64ac1af37df16d5de66f451b6f6da3f6ee27d7a75b4e90e61e8ef2358a"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "e00c356b035ce5bd995f4d2d7b195e63f611c4572953582dee5d8271843cd9c7"

--- a/Formula/fzn2lp.rb
+++ b/Formula/fzn2lp.rb
@@ -8,6 +8,7 @@ class Fzn2lp < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sonoma: "cb2e7850b7236d99b6faa2eff9661e65ed3087044b7cfaf7c8d626d9b2ac9cb7"
     sha256 cellar: :any_skip_relocation, ventura:      "9267efb06ffe50455bb607cb97bab2a6de2894b26338c7a5d291d3b37bbd94f2"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "f93d54aaf101a0c1bb18889c3d3e11b4eccea93d5a3d45a377867c6ff6e6bd53"

--- a/Formula/geas.rb
+++ b/Formula/geas.rb
@@ -8,6 +8,7 @@ class Geas < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sonoma: "e64c83bd7fd6befe7f637ca72bc71e7b83525fcf47fdf50de83a2ccb60163d03"
     sha256 cellar: :any_skip_relocation, ventura:      "abab9a4b7f089fe820406119fea356a184ed1e6c07a7ecd852f5183c9cd94256"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "2bb70e0286b9190148f10806583f21835001cff885d77bb8a4ebe67337991d2f"

--- a/Formula/geas.rb
+++ b/Formula/geas.rb
@@ -19,6 +19,9 @@ class Geas < Formula
   def install
     inreplace "Makefile" do |s|
       s.gsub!("-march=native", "")
+      # - GCC 13+ no longer transitively includes <cstdint>, so force-include.
+      # - Clang 19+ rejects the bare `template` keyword; downgrade that diagnostic.
+      s.gsub!("--std=c++11", "--std=c++11 -include cstdint -Wno-missing-template-arg-list-after-template-kw")
     end
     Dir.mktmpdir("opamroot") do |opamroot|
       ENV["OPAMROOT"] = opamroot

--- a/Formula/jacop.rb
+++ b/Formula/jacop.rb
@@ -8,6 +8,7 @@ class Jacop < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any_skip_relocation, ventura:      "3f6b2910459b3650c11f46a4135d37f213a96d5a88ba7ee41efb44dcd0105c5b"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "9fa4169e8eab88dcea4cb2458010079d5595a6589f1a66e681ec3d68d99ea103"
   end

--- a/Formula/open-wbo.rb
+++ b/Formula/open-wbo.rb
@@ -9,6 +9,7 @@ class OpenWbo < Formula
 
   bottle do
     root_url "https://ghcr.io/v2/dekker1/minizinc"
+    rebuild 1
     sha256 cellar: :any,                 monterey:     "9b4746d1f00bb5227e68b1d60f714f0543009571f923f47084a9f208238a03a7"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "812ed111a61cf4dbbeb70f6114bfb785846e97eb0d99aea18cc25cc2cf15e403"
   end


### PR DESCRIPTION
Bumps the `rebuild` counter on every formula whose bottles are out of date, so CI rebuilds them across the current matrix (arm64 macOS / Intel macOS / Linux) and `brew pr-pull` republishes them.

**No arm64 macOS bottle at all** (build from source on Apple Silicon today): clingcon, jacop, open-wbo, findmus, flatzingo, fzn-oscar-cbls.

**Still on `arm64_sonoma`** (work on Tahoe via fallback, refreshed to current): chuffed, fzn-picat, fzn2lp, geas.

The pure-Java (jacop, fzn-oscar-cbls) and Python-script (flatzingo) formulae should collapse into `:all` bottles if their per-platform artifacts come out identical.

Note: flatzingo depends on clingcon at runtime, so its arm build relies on clingcon building on arm in the same run. open-wbo (2019 C++) is the most likely to need a build fix.